### PR TITLE
#10-ModifyManyToMany

### DIFF
--- a/backend/src/main/java/com/project/backend/accounts/repository/MarketAdminRepository.java
+++ b/backend/src/main/java/com/project/backend/accounts/repository/MarketAdminRepository.java
@@ -2,8 +2,5 @@ package com.project.backend.accounts.repository;
 
 import com.project.backend.accounts.entity.MarketAdmin;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
 public interface MarketAdminRepository extends JpaRepository<MarketAdmin, String> {
 }

--- a/backend/src/main/java/com/project/backend/accounts/repository/RestaurantReviewRepository.java
+++ b/backend/src/main/java/com/project/backend/accounts/repository/RestaurantReviewRepository.java
@@ -2,8 +2,5 @@ package com.project.backend.accounts.repository;
 
 import com.project.backend.accounts.entity.RestaurantReview;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
 public interface RestaurantReviewRepository extends JpaRepository<RestaurantReview, String> {
 }

--- a/backend/src/main/java/com/project/backend/accounts/repository/UserRepository.java
+++ b/backend/src/main/java/com/project/backend/accounts/repository/UserRepository.java
@@ -2,8 +2,5 @@ package com.project.backend.accounts.repository;
 
 import com.project.backend.accounts.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
 public interface UserRepository extends JpaRepository<User, String> {
 }

--- a/backend/src/main/java/com/project/backend/places/repository/ContentTypeRepository.java
+++ b/backend/src/main/java/com/project/backend/places/repository/ContentTypeRepository.java
@@ -2,8 +2,5 @@ package com.project.backend.places.repository;
 
 import com.project.backend.places.repository.entity.ContentType;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
 public interface ContentTypeRepository extends JpaRepository<ContentType,Integer> {
 }

--- a/backend/src/main/java/com/project/backend/places/repository/CulturalEventRepository.java
+++ b/backend/src/main/java/com/project/backend/places/repository/CulturalEventRepository.java
@@ -2,8 +2,5 @@ package com.project.backend.places.repository;
 
 import com.project.backend.places.repository.entity.CulturalEvent;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
 public interface CulturalEventRepository extends JpaRepository<CulturalEvent,Integer> {
 }

--- a/backend/src/main/java/com/project/backend/places/repository/DistrictRepository.java
+++ b/backend/src/main/java/com/project/backend/places/repository/DistrictRepository.java
@@ -2,8 +2,5 @@ package com.project.backend.places.repository;
 
 import com.project.backend.places.repository.entity.District;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
 public interface DistrictRepository extends JpaRepository<District, Integer> {
 }

--- a/backend/src/main/java/com/project/backend/places/repository/HotplacesRepository.java
+++ b/backend/src/main/java/com/project/backend/places/repository/HotplacesRepository.java
@@ -2,8 +2,5 @@ package com.project.backend.places.repository;
 
 import com.project.backend.places.repository.entity.Hotplaces;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
 public interface HotplacesRepository extends JpaRepository<Hotplaces,Integer> {
 }

--- a/backend/src/main/java/com/project/backend/places/repository/PlaceCategoryRepository.java
+++ b/backend/src/main/java/com/project/backend/places/repository/PlaceCategoryRepository.java
@@ -2,8 +2,5 @@ package com.project.backend.places.repository;
 
 import com.project.backend.places.repository.entity.PlaceCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
 public interface PlaceCategoryRepository extends JpaRepository<PlaceCategory, Integer> {
 }

--- a/backend/src/main/java/com/project/backend/places/repository/PlaceDistrictRepository.java
+++ b/backend/src/main/java/com/project/backend/places/repository/PlaceDistrictRepository.java
@@ -1,0 +1,7 @@
+package com.project.backend.places.repository;
+
+import com.project.backend.places.repository.entity.PlaceDistrict;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlaceDistrictRepository extends JpaRepository<PlaceDistrict, Integer> {
+}

--- a/backend/src/main/java/com/project/backend/places/repository/PlaceRepository.java
+++ b/backend/src/main/java/com/project/backend/places/repository/PlaceRepository.java
@@ -2,8 +2,5 @@ package com.project.backend.places.repository;
 
 import com.project.backend.places.repository.entity.Place;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
 public interface PlaceRepository extends JpaRepository<Place, String> {
 }

--- a/backend/src/main/java/com/project/backend/places/repository/PlaceSubwayRepository.java
+++ b/backend/src/main/java/com/project/backend/places/repository/PlaceSubwayRepository.java
@@ -1,0 +1,7 @@
+package com.project.backend.places.repository;
+
+import com.project.backend.places.repository.entity.PlaceSubway;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlaceSubwayRepository extends JpaRepository<PlaceSubway,Integer> {
+}

--- a/backend/src/main/java/com/project/backend/places/repository/SubwayDetailRepository.java
+++ b/backend/src/main/java/com/project/backend/places/repository/SubwayDetailRepository.java
@@ -2,8 +2,6 @@ package com.project.backend.places.repository;
 
 import com.project.backend.places.repository.entity.SubwayDetail;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface SubwayDetailRepository extends JpaRepository<SubwayDetail,Integer> {
 }

--- a/backend/src/main/java/com/project/backend/places/repository/SubwayRepository.java
+++ b/backend/src/main/java/com/project/backend/places/repository/SubwayRepository.java
@@ -2,8 +2,5 @@ package com.project.backend.places.repository;
 
 import com.project.backend.places.repository.entity.Subway;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
 public interface SubwayRepository extends JpaRepository<Subway,Integer> {
 }

--- a/backend/src/main/java/com/project/backend/places/repository/entity/District.java
+++ b/backend/src/main/java/com/project/backend/places/repository/entity/District.java
@@ -1,11 +1,9 @@
 package com.project.backend.places.repository.entity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 
 import javax.persistence.*;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.List;
 
 @Entity
 @Builder
@@ -23,8 +21,8 @@ public class District {
     @Column(name = "district_nm")
     private String districtName;
 
-    @JsonIgnore
-    @ManyToMany(mappedBy = "assignedDistricts")
-    private Set<Place> places = new HashSet<>();
+    // 연결 테이블(MEMBER_PRODUCT)쪽이 외래키를 갖고있기 때문에, 연결 테이블이 연관관계의 주인이다.
+    @OneToMany(mappedBy = "district")
+    private List<PlaceDistrict> placeDistricts;
 
 }

--- a/backend/src/main/java/com/project/backend/places/repository/entity/Place.java
+++ b/backend/src/main/java/com/project/backend/places/repository/entity/Place.java
@@ -3,8 +3,7 @@ package com.project.backend.places.repository.entity;
 import lombok.*;
 
 import javax.persistence.*;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.List;
 
 @Entity
 @Builder
@@ -26,18 +25,11 @@ public class Place {
     @JoinColumn(name="category_id")
     private PlaceCategory placeCategory;
 
-    @ManyToMany
-    @JoinTable(name = "place_district",
-            joinColumns = @JoinColumn(name = "place_id"),
-            inverseJoinColumns = @JoinColumn(name = "district_id")
-    )
-    private Set<District> assignedDistricts = new HashSet<>();
+    // 연결 테이블(MEMBER_PRODUCT)쪽이 외래키를 갖고있기 때문에, 연결 테이블이 연관관계의 주인이다.
+    @OneToMany(mappedBy = "place")
+    private List<PlaceDistrict> placeDistricts;
 
-
-    @ManyToMany
-    @JoinTable(name = "place_subway",
-            joinColumns = @JoinColumn(name = "place_id"),
-            inverseJoinColumns = @JoinColumn(name = "subway_id")
-    )
-    private Set<Subway> assignedSubways = new HashSet<>();
+    // 연결 테이블(MEMBER_PRODUCT)쪽이 외래키를 갖고있기 때문에, 연결 테이블이 연관관계의 주인이다.
+    @OneToMany(mappedBy = "place")
+    private List<PlaceSubway> placeSubways;
 }

--- a/backend/src/main/java/com/project/backend/places/repository/entity/PlaceDistrict.java
+++ b/backend/src/main/java/com/project/backend/places/repository/entity/PlaceDistrict.java
@@ -1,0 +1,28 @@
+package com.project.backend.places.repository.entity;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Table(name = "place_district")
+public class PlaceDistrict {
+
+
+    @ManyToOne
+    @JoinColumn(name = "place_id")
+    private Place place;
+
+    @ManyToOne
+    @JoinColumn(name = "district_id")
+    private District district;
+
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+}

--- a/backend/src/main/java/com/project/backend/places/repository/entity/PlaceSubway.java
+++ b/backend/src/main/java/com/project/backend/places/repository/entity/PlaceSubway.java
@@ -1,0 +1,26 @@
+package com.project.backend.places.repository.entity;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Table(name = "place_subway")
+public class PlaceSubway {
+
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @ManyToOne
+    @JoinColumn(name = "place_id")
+    private Place place;
+
+    @ManyToOne
+    @JoinColumn(name = "subway_id")
+    private Subway subway;
+}

--- a/backend/src/main/java/com/project/backend/places/repository/entity/Subway.java
+++ b/backend/src/main/java/com/project/backend/places/repository/entity/Subway.java
@@ -1,10 +1,8 @@
 package com.project.backend.places.repository.entity;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 
 import javax.persistence.*;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.List;
 
 @Entity
 @Builder
@@ -21,7 +19,7 @@ public class Subway {
     @Column(name = "subway_nm", length = 30)
     private String subwayName;
 
-    @JsonIgnore
-    @ManyToMany(mappedBy = "assignedSubways")
-    private Set<Place> places = new HashSet<>();
+    // 연결 테이블(MEMBER_PRODUCT)쪽이 외래키를 갖고있기 때문에, 연결 테이블이 연관관계의 주인이다.
+    @OneToMany(mappedBy = "subway")
+    private List<PlaceSubway> placeSubways;
 }

--- a/backend/src/main/java/com/project/backend/population/repository/PopulationCongestMsgRepository.java
+++ b/backend/src/main/java/com/project/backend/population/repository/PopulationCongestMsgRepository.java
@@ -2,8 +2,5 @@ package com.project.backend.population.repository;
 
 import com.project.backend.population.repository.entity.PopulationCongestMsg;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
 public interface PopulationCongestMsgRepository extends JpaRepository<PopulationCongestMsg,String> {
 }

--- a/backend/src/main/java/com/project/backend/population/repository/PopulationRepository.java
+++ b/backend/src/main/java/com/project/backend/population/repository/PopulationRepository.java
@@ -2,11 +2,6 @@ package com.project.backend.population.repository;
 
 import com.project.backend.population.repository.entity.Population;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-import java.util.List;
-
-@Repository
 public interface PopulationRepository extends JpaRepository<Population,Integer> {
 //    List<Population> findTop48ByIdOrderByDesc();
 }

--- a/backend/src/main/java/com/project/backend/population/repository/entity/Population.java
+++ b/backend/src/main/java/com/project/backend/population/repository/entity/Population.java
@@ -1,7 +1,5 @@
 package com.project.backend.population.repository.entity;
 
-
-import com.project.backend.places.repository.entity.District;
 import com.project.backend.places.repository.entity.Place;
 import lombok.*;
 

--- a/backend/src/main/java/com/project/backend/restaurants/repository/RestaurantBreaktimeRepository.java
+++ b/backend/src/main/java/com/project/backend/restaurants/repository/RestaurantBreaktimeRepository.java
@@ -2,8 +2,5 @@ package com.project.backend.restaurants.repository;
 
 import com.project.backend.restaurants.repository.entity.RestaurantBreaktime;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
 public interface RestaurantBreaktimeRepository extends JpaRepository<RestaurantBreaktime,Integer> {
 }

--- a/backend/src/main/java/com/project/backend/restaurants/repository/RestaurantCategoryRepository.java
+++ b/backend/src/main/java/com/project/backend/restaurants/repository/RestaurantCategoryRepository.java
@@ -2,8 +2,5 @@ package com.project.backend.restaurants.repository;
 
 import com.project.backend.restaurants.repository.entity.RestaurantCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
 public interface RestaurantCategoryRepository extends JpaRepository<RestaurantCategory,Integer> {
 }

--- a/backend/src/main/java/com/project/backend/restaurants/repository/RestaurantRepository.java
+++ b/backend/src/main/java/com/project/backend/restaurants/repository/RestaurantRepository.java
@@ -2,8 +2,5 @@ package com.project.backend.restaurants.repository;
 
 import com.project.backend.restaurants.repository.entity.Restaurant;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
 public interface RestaurantRepository extends JpaRepository<Restaurant,Integer> {
 }

--- a/backend/src/main/java/com/project/backend/restaurants/repository/RestaurantRuntimeRepository.java
+++ b/backend/src/main/java/com/project/backend/restaurants/repository/RestaurantRuntimeRepository.java
@@ -2,8 +2,5 @@ package com.project.backend.restaurants.repository;
 
 import com.project.backend.restaurants.repository.entity.RestaurantRuntime;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
 public interface RestaurantRuntimeRepository extends JpaRepository<RestaurantRuntime,Integer> {
 }

--- a/backend/src/main/java/com/project/backend/test/repository/CrudEntityRepository.java
+++ b/backend/src/main/java/com/project/backend/test/repository/CrudEntityRepository.java
@@ -4,11 +4,8 @@ import com.project.backend.test.entity.CrudEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
-
-@Repository
 public interface CrudEntityRepository extends JpaRepository<CrudEntity,String> {
 
     @Query(value = "select name, age from sample_member where name = :name", nativeQuery = true)

--- a/backend/src/main/java/com/project/backend/weather/repository/WeatherFcstRepository.java
+++ b/backend/src/main/java/com/project/backend/weather/repository/WeatherFcstRepository.java
@@ -2,8 +2,5 @@ package com.project.backend.weather.repository;
 
 import com.project.backend.weather.repository.entity.Weather;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
 public interface WeatherFcstRepository extends JpaRepository<Weather,Integer> {
 }

--- a/backend/src/main/java/com/project/backend/weather/repository/WeatherRepository.java
+++ b/backend/src/main/java/com/project/backend/weather/repository/WeatherRepository.java
@@ -2,8 +2,5 @@ package com.project.backend.weather.repository;
 
 import com.project.backend.weather.repository.entity.WeatherFcst;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
 public interface WeatherRepository extends JpaRepository<WeatherFcst,Integer> {
 }

--- a/backend/src/test/java/com/project/backend/data/repository/DataRepositoryTest.java
+++ b/backend/src/test/java/com/project/backend/data/repository/DataRepositoryTest.java
@@ -1,0 +1,24 @@
+package com.project.backend.data.repository;
+
+import com.project.backend.places.repository.entity.Place;
+import com.project.backend.places.repository.PlaceRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+@SpringBootTest
+public class DataRepositoryTest {
+
+    @Autowired private PlaceRepository placeRepository;
+
+    @Test
+    public void crudTest() {
+
+        List<Place> placeSearch = placeRepository.findAll();
+        for (Place place : placeSearch) {
+            System.out.println(place.toString());
+        }
+    }
+}

--- a/backend/src/test/java/com/project/backend/population/repository/populationRepositoryTest.java
+++ b/backend/src/test/java/com/project/backend/population/repository/populationRepositoryTest.java
@@ -1,0 +1,71 @@
+package com.project.backend.population.repository;
+
+import com.project.backend.places.repository.CulturalEventRepository;
+import com.project.backend.places.repository.PlaceCategoryRepository;
+import com.project.backend.places.repository.entity.CulturalEvent;
+import com.project.backend.places.repository.entity.PlaceCategory;
+import com.project.backend.population.repository.entity.Population;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+@SpringBootTest
+public class populationRepositoryTest {
+
+    CulturalEventRepository culturalEventRepository;
+    PlaceCategoryRepository placeCategoryRepository;
+
+    @Autowired
+    public populationRepositoryTest( CulturalEventRepository culturalEventRepository, PlaceCategoryRepository placeCategoryRepository) {
+        this.culturalEventRepository = culturalEventRepository;
+        this.placeCategoryRepository = placeCategoryRepository;
+    }
+
+
+//    @Test
+//    void testJpa1() {
+//        List<Population> populations = this.populationRepository.findTop48OrderByIdDesc();
+//        for(Population population :populations){
+//            System.out.println(population);
+//        }
+//    }
+//    @Test
+//    void testJpa2() {
+//        List<Population> populations = this.populationRepository.findAllOrderByIdDesc();
+//        for(Population population :populations){
+//            System.out.println(population);
+//        }
+//    }
+//    @Test
+//    void testJpa3() {
+//        List<Population> populations = this.populationRepository.findAllByIdDesc();
+//        for(Population population :populations){
+//            System.out.println(population);
+//        }
+//    }
+//    @Test
+//    void testJpa4() {
+//        int id = 4;
+//        Population population = this.populationRepository.findById(4).get();
+//        System.out.println(population);
+//    }
+//
+//    @Test
+//    void testJpa5() {
+//        List<PlaceCategory> placeCategories = this.placeCategoryRepository.findAll();
+//        for(PlaceCategory palceCategory :placeCategories){
+//            System.out.println(palceCategory);
+//        }
+//    }
+
+    @Test
+    void testJpa6() {
+        List<CulturalEvent> culturalEvents = this.culturalEventRepository.findAll();
+        for(CulturalEvent culturalEvent  :culturalEvents){
+            System.out.println(culturalEvent);
+        }
+    }
+}


### PR DESCRIPTION
ManyTOMany 어노테이션으로 발생하는 순환문제를 해결하기 위해 table을 생성하여 oneToMany, ManyToOne 코드로 변경하였습니다. 그리고 JpaRepository를 상속받으면 필요없게 되는 어노테이션인 Repository 어노테이션을 삭제했습니다.